### PR TITLE
use dynamic public path for runtime imports

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,1 @@
+ASSET_PATH = '/app/themes/sage/public/'

--- a/bud.config.js
+++ b/bud.config.js
@@ -32,6 +32,15 @@ module.exports = (app) =>
     ])
 
     /**
+     * Define the public path for dynamically imported assets.
+     *
+     * I am defining it an .env file and accessing it with `bud.env`.
+     */
+    .define({
+      ASSET_PATH: JSON.stringify(app.env.get('ASSET_PATH')),
+    })
+
+    /**
      * Target URL to be proxied by the dev server.
      *
      * This is your local dev server.

--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -1,3 +1,4 @@
+import './publicPath';
 import {componentsList} from './componentsList';
 
 /**

--- a/resources/scripts/publicPath.js
+++ b/resources/scripts/publicPath.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-undef
+__webpack_public_path__ = ASSET_PATH;


### PR DESCRIPTION
I did this with the bud api for accessing local .env values. You don't have to do that. You could just pass a string. You could also hardcode it into the app, although that's less portable.

References:

- bud.define docs: https://budjs.netlify.app/docs/bud.define
- webpack docs: https://webpack.js.org/guides/public-path/
